### PR TITLE
Fix audiogen app CMakeFiles to use correct variable name for sources

### DIFF
--- a/kleidiai-examples/audiogen/app/CMakeLists.txt
+++ b/kleidiai-examples/audiogen/app/CMakeLists.txt
@@ -74,7 +74,7 @@ set(SENTENCEPIECE_LIB ${BINARY_DIR}/src/libsentencepiece.a)
 # Define source
 set(SRCS audiogen.cpp)
 
-add_executable(audiogen ${srcs})
+add_executable(audiogen ${SRCS})
 
 set(XNNPACK_ENABLE_ARM_SME2 OFF CACHE BOOL "" FORCE)
 set(TFLITE_HOST_TOOLS_DIR "${FLATBUFFERS_BIN_DIR}/_deps/flatbuffers-build" CACHE PATH "Host tools directory")


### PR DESCRIPTION
The CMake file has an error on line 77 where the variable used for the audiogen app sources is in the wrong case. This fixes the file to use the proper upper-case variable name.